### PR TITLE
Fixed incorrect error reporting

### DIFF
--- a/software/docs/TutorialSession.md
+++ b/software/docs/TutorialSession.md
@@ -797,7 +797,7 @@ features.
 	  int light = 0;
 	  err_code = isl29035_read_light_intensity();
 	  if (err_code < SUCCESS) {
-		printf("Error reading from light sensor: %d\n", light);
+		printf("Error reading from light sensor: %d\n", err_code);
 	  } else {
 		light = err_code;
 		err_code = SUCCESS;


### PR DESCRIPTION
It would just print light, which is always 0