### PR TITLE
Changed spreading factor

### DIFF
--- a/software/apps/libsignpost/RadioDefs.h
+++ b/software/apps/libsignpost/RadioDefs.h
@@ -249,7 +249,7 @@ typedef struct RadioMsg_T
 // rx window default, no window
 #define COMRADIO_CFG_DEFAULT_RFRXWINDOW         3000 // 3s
 // default spreading factor = 7
-#define COMRADIO_CFG_DEFAULT_RFSPREADINGFACTOR  RF_LORA_SF_11
+#define COMRADIO_CFG_DEFAULT_RFSPREADINGFACTOR  RF_LORA_SF_7
 // default tx group address
 #define COMRADIO_CFG_DEFAULT_TXGROUPADDRESS     0x10
 // default tx address: broadcast


### PR DESCRIPTION
Default listening SF for the deployed signpost is now 7. I don't think anyone or anything else is depending on this staying the same at the moment.